### PR TITLE
Build Docker image with multi stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.11
+FROM takanabe/add-new-issues-to-project-column:0.1
 
 LABEL "com.github.actions.name"="Add new issues to a designate project column"
-LABEL "com.github.actions.description"="GitHub Actions place new issues to a designate GitHub project column"
+LABEL "com.github.actions.description"="GitHub Actions adding new issues to a specified project column automatically"
 LABEL "com.github.actions.icon"="terminal"
 LABEL "com.github.actions.color"="purple"
 
@@ -9,14 +9,4 @@ LABEL "repository"="https://github.com/takanabe/add-new-issues-to-project-column
 LABEL "homepage"="https://github.com/takanabe/add-new-issues-to-project-column"
 LABEL "maintainer"="Takayuki Watanabe <takanabe.w@gmail.com>"
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
-
-RUN mkdir /app
-COPY . /app/
-WORKDIR /app
-
-RUN go mod download
-RUN go build -o main .
-
-ENTRYPOINT ["/app/main"]
+CMD ["/app/main"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,14 @@
+FROM golang:1.12 as builder
+# Force the go compiler to use modules
+ENV GO111MODULE=on
+RUN mkdir /app
+COPY . /app/
+WORKDIR /app
+RUN go mod download
+RUN CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o main .
+RUN ls
+
+FROM scratch
+WORKDIR /app
+COPY --from=builder /app/main ./
+CMD ["/app/main"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ To develop GitHub Actions in your local environment, use [act](https://github.co
 
 VSCode debug config example is [here](https://github.com/takanabe/add-new-issues-to-project-column/blob/master/.vscode/launch.json.example). `GITHUB_TOKEN` is necessary to access your repository and  project.
 
+
+## Build Docker image and update DockerHub
+
+```
+$ docker build -f Dockerfile.build . -t add_issue_to_project
+$ docker image tag add_issue_to_project takanabe/add-new-issues-to-project-column:0.1
+$ docker login
+$ docker push takanabe/add-new-issues-to-project-column:0.1
+```
+
 ## License
 
 [Apache 2.0](https://github.com/takanabe/add-new-issues-to-project-column/blob/master/LICENSE)


### PR DESCRIPTION
To reduce build time in GitHub Actions workflow, eliminate unnecessary build steps by using a pre-build image.

The pre-build image is upload on https://hub.docker.com/r/takanabe/add-new-issues-to-project-column