### PR TITLE
Support all event actions in addition to "opened" action

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -44,11 +44,6 @@ func issueEventPayload() github.IssuesEvent {
 	if err != nil {
 		errorLog(errors.Wrap(err, "Failed to unmarshal JSON to Go Object"))
 	}
-	if payload.GetAction() != "opened" {
-		infoLog("GitHub action interupts!!")
-		infoLog("This issue is not new one :D")
-		os.Exit(0)
-	}
 
 	return payload
 }

--- a/pull_requests.go
+++ b/pull_requests.go
@@ -44,11 +44,6 @@ func pullRequestEventPayload() github.PullRequestEvent {
 	if err != nil {
 		errorLog(errors.Wrap(err, "Failed to unmarshal JSON to Go Object"))
 	}
-	if payload.GetAction() != "opened" {
-		infoLog("GitHub action interupts!!")
-		infoLog("This PR is not new one :D")
-		os.Exit(0)
-	}
 
 	return payload
 }


### PR DESCRIPTION
## Background

GitHub Actions supports conditional statement in its yaml file
and users can manage the target event actions with the statement.

```
if: github.event_name == 'issues' && github.event.action == 'closed'
```

## Goal

* Remove unnecessary conditions to detect event action types.