### PR TITLE
Add catch for error on adding to project it's already associated with.

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,6 +238,11 @@ func addToProject(ctx context.Context, client *github.Client, eventID, columnID 
 
 	err = validateGitHubResponse(res, err)
 	if err != nil {
+		// Catch error if the issue is already on that
+		if err.Message == "Project already has the associated issue" {
+			infoLog("Project already has the associated issue...skipping")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
An issue I've ran into is that the job will run on against issue updates/adds when it's already associated with the given project. In those cases, this error is thrown...

```
Error: /21 17:30:36 [ERROR] POST https://api.github.com/projects/columns/11063427/cards: 422 Validation Failed [{Resource:ProjectCard Field:data Code:unprocessable Message:Project already has the associated issue}]
Failed to get results from GitHub
```

Added a check for this message which will just add a note to the info log but not throw an error.

Signed-off-by: John Mertic <jmertic@linuxfoundation.org>